### PR TITLE
Fix formatting for offensive matches in MatchCard & MatchTable

### DIFF
--- a/src/components/MatchCard/MatchCard.tsx
+++ b/src/components/MatchCard/MatchCard.tsx
@@ -23,6 +23,17 @@ type MatchCardProps = {
   clanId?: string;
 };
 
+const matchMode = (match: Match, clanId: string): string => {
+  let factionRe = /(Allie)s/;
+  let mode = " ("
+  if (match?.offensive) {
+    const side = match?.clans1_ids.includes(clanId) ? match?.side1 : match?.side2;
+    mode += side ? side.replace(factionRe, "$1d") + " " : ""
+    return mode + "Offensive)"
+  }
+  return mode + "Warfare)"
+}
+
 export const MatchCard: FC<MatchCardProps> = ({ match, clanId }) => {
   const [sortedMatch, setSortedMatch] = useState<SortedMatch>();
   const { getTag } = useClanTags();
@@ -61,7 +72,7 @@ export const MatchCard: FC<MatchCardProps> = ({ match, clanId }) => {
             friendlyCaps={sortedMatch?.friendlyCaps}
             enemyCaps={sortedMatch?.enemyCaps}
             offensive={sortedMatch?.offensive}
-            attacker={match?.clans1_ids.includes(clanId || "")}
+            attacker={match?.clans1_ids.includes(clanId)}
           />
           <AutoTextSkeleton className="text-2xl min-w-[3rem] text-center font-mono grid grid-cols-[1fr_min-content_1fr] flex-1">
             {sortedMatch && (
@@ -119,7 +130,7 @@ export const MatchCard: FC<MatchCardProps> = ({ match, clanId }) => {
           </AutoTextSkeleton>
           <AutoTextSkeleton className="min-w-[3rem] text-center">
             {match?.map}
-            {match?.offensive && ` (Offensive ${match.side1})`}
+            {matchMode(match)}
           </AutoTextSkeleton>
 
           <AutoTextSkeleton className="min-w-[3rem] text-center ">

--- a/src/components/MatchCard/WinLooseBanner.tsx
+++ b/src/components/MatchCard/WinLooseBanner.tsx
@@ -23,7 +23,7 @@ export const WinLoseBanner: FC<WinLoseBannerProps> = ({
     text = "\u200B";
     background = "bg-gray-700";
   } else if (
-    (offensive && (attacker ? friendlyCaps : enemyCaps) === MAX_CAPS) ||
+    (offensive && (attacker ? friendlyCaps === MAX_CAPS : enemyCaps !== MAX_CAPS)) ||
     (!offensive && friendlyCaps > enemyCaps)
   ) {
     text = "VICTORY";


### PR DESCRIPTION
- Fixes MatchCard WinLoseBanner (some victories defaulted to Defeat)
- Fixes offensive mode formatting in MatchCard, e.g. Warfare, <Faction> Offensive
- Introduce "Mode" column on Match table, e.g. Warfare, <Faction> Offensive
- Reintroduce "Result" column on Clan page